### PR TITLE
chore: envar injection in vite

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,13 +1,17 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Luncswap</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Luncswap</title>
+  %injectedScript%
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,6 @@
     "@types/compression": "^1.7.5",
     "@types/express": "^4.17.21",
     "@types/lodash": "^4.14.202",
-    "@types/mustache": "^4.2.5",
     "@types/node": "^20.11.4",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "tsx server.ts",
+    "dev": "tsx watch --clear-screen=false --ignore ./*.mjs server.ts",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
@@ -24,6 +24,7 @@
     "@xstate/inspect": "^0.8.0",
     "@xstate/react": "^4.0.1",
     "chakra-react-select": "^4.7.6",
+    "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "framer-motion": "^10.16.16",
     "i18next": "^23.7.11",
@@ -45,6 +46,7 @@
     "@types/compression": "^1.7.5",
     "@types/express": "^4.17.21",
     "@types/lodash": "^4.14.202",
+    "@types/mustache": "^4.2.5",
     "@types/node": "^20.11.4",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -1,36 +1,88 @@
+import { config } from "dotenv";
 import path from "path";
 import express from "express";
-// import fs from "node:fs/promises";
+import fs from "node:fs/promises";
 import { fileURLToPath } from "node:url";
-import { createServer as createViteServer } from "vite";
+import { ViteDevServer } from "vite";
 import compression from "compression";
 import serveStatic from "serve-static";
 
-const isDev =
-  process.env.NODE_ENV === "development" ||
-  process.env.VITE_DEV_SERVER === "true";
+config();
+
+const isDev = process.env.NODE_ENV !== "production";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const resolve = (p: string) => path.resolve(__dirname, p);
 
+let vite: ViteDevServer;
+
+// create script to inject env within window.__PUBLIC_ENV__ object
+// filter only env with prefix PUBLIC_
+// this env will be injected into window object
+const compileEnvScript = () => {
+  const instructionList: string[] = ["window.__PUBLIC_ENV__ = {};"];
+  Object.keys(process.env).forEach(key => {
+    if (key.startsWith("PUBLIC_")) {
+      instructionList.push(
+        `window.__PUBLIC_ENV__["${key}"] = "${process.env[key]}";`,
+      );
+    }
+  });
+  return `<script>${instructionList.reduce(
+    (acc, val) => acc + "\n" + val,
+    "",
+  )}</script>`;
+};
+
+const compileHTML = (() => {
+  let cache = "";
+  return async (url: string) => {
+    if (cache !== "") return cache;
+    const injectedScript = compileEnvScript();
+
+    if (isDev) {
+      const html = resolve("./index.html");
+      const htmlString = await fs.readFile(html, { encoding: "utf-8" });
+      const compiledHTMLString = htmlString.replace(
+        "%injectedScript%",
+        injectedScript,
+      );
+      const result = await vite.transformIndexHtml(url, compiledHTMLString);
+      cache = result;
+      return result;
+    } else {
+      const html = resolve("./dist/index.html");
+      const htmlString = await fs.readFile(html, { encoding: "utf-8" });
+      const result = htmlString.replace("%injectedScript%", injectedScript);
+      cache = result;
+      return result;
+    }
+  };
+})();
+
 const createServer = async () => {
   const app = express();
-  const vite = await createViteServer({
-    server: { middlewareMode: true },
-    logLevel: isDev ? "error" : "info",
-    root: resolve("."),
-  });
-
-  app.use(vite.middlewares);
+  app.use(express.static(resolve("public")));
 
   if (isDev) {
-    app.use(express.static(resolve("public")));
+    const { createServer } = await import("vite");
+    vite = await createServer({
+      server: { middlewareMode: true },
+      appType: "custom",
+    });
+    app.use(vite.middlewares);
   } else {
     app.use(compression());
     app.use(serveStatic(resolve("dist"), { index: false }));
   }
+
+  app.get("*", async (req, res) => {
+    const url = req.originalUrl;
+    const htmlString = await compileHTML(url);
+    res.status(200).set({ "Content-Type": "text/html" }).end(htmlString);
+  });
 
   const port = process.env.PORT || 3000;
   app.listen(Number(port), "0.0.0.0", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,9 +135,6 @@ importers:
       '@types/lodash':
         specifier: ^4.14.202
         version: 4.14.202
-      '@types/mustache':
-        specifier: ^4.2.5
-        version: 4.2.5
       '@types/node':
         specifier: ^20.11.4
         version: 20.11.4
@@ -4418,10 +4415,6 @@ packages:
   /@types/minimatch@5.1.2:
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
     dev: false
-
-  /@types/mustache@4.2.5:
-    resolution: {integrity: sha512-PLwiVvTBg59tGFL/8VpcGvqOu3L4OuveNvPi0EYbWchRdEVP++yRUXJPFl+CApKEq13017/4Nf7aQ5lTtHUNsA==}
-    dev: true
 
   /@types/node@10.12.18:
     resolution: {integrity: sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       chakra-react-select:
         specifier: ^4.7.6
         version: 4.7.6(@chakra-ui/form-control@2.2.0)(@chakra-ui/icon@3.2.0)(@chakra-ui/layout@2.3.1)(@chakra-ui/media-query@3.3.0)(@chakra-ui/menu@2.2.1)(@chakra-ui/spinner@2.1.0)(@chakra-ui/system@2.6.2)(@emotion/react@11.11.1)(@types/react@18.2.42)(react-dom@18.2.0)(react@18.2.0)
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.3.1
       express:
         specifier: ^4.18.2
         version: 4.18.2
@@ -132,6 +135,9 @@ importers:
       '@types/lodash':
         specifier: ^4.14.202
         version: 4.14.202
+      '@types/mustache':
+        specifier: ^4.2.5
+        version: 4.2.5
       '@types/node':
         specifier: ^20.11.4
         version: 20.11.4
@@ -4412,6 +4418,10 @@ packages:
   /@types/minimatch@5.1.2:
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
     dev: false
+
+  /@types/mustache@4.2.5:
+    resolution: {integrity: sha512-PLwiVvTBg59tGFL/8VpcGvqOu3L4OuveNvPi0EYbWchRdEVP++yRUXJPFl+CApKEq13017/4Nf7aQ5lTtHUNsA==}
+    dev: true
 
   /@types/node@10.12.18:
     resolution: {integrity: sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==}


### PR DESCRIPTION
When we are using `BFF` in frontend we can take advantage of it's node runtime that can read through `process.env` and inject whatever value so it will be available in frontend.

### BFF
BFF is stands for Backend For Frontend

in this way, we can inject envar at runtime, we don't have to rebuild the `js` assets like `Next.js`